### PR TITLE
Fix override definition with configuration setup on request factory

### DIFF
--- a/tests/RequestFactoryTest.php
+++ b/tests/RequestFactoryTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Route;
 use Magdonia\LaravelFactories\RequestFactory;
 use Magdonia\LaravelFactories\Tests\Stubs\AnotherRequestFactory;
 use Magdonia\LaravelFactories\Tests\Stubs\AuthenticatedRequest;
+use Magdonia\LaravelFactories\Tests\Stubs\ConfiguredRequest;
 use Magdonia\LaravelFactories\Tests\Stubs\NewRequest;
 use Magdonia\LaravelFactories\Tests\Stubs\SimpleRequest;
 use Magdonia\LaravelFactories\Tests\Stubs\SimpleRequestFactory;
@@ -81,6 +82,19 @@ class RequestFactoryTest extends TestCase
 
         $this->assertArrayHasKey($key, $form);
         $this->assertEquals($form[$key], $value);
+    }
+
+    public function test_configure_should_be_called_before_definition(): void
+    {
+        $factory = ConfiguredRequest::factory();
+        $this->assertEquals($factory->title, $factory->form()['title']);
+    }
+
+    public function test_states_can_override_configure_setup(): void
+    {
+        $title = $this->faker->sentence();
+        $factory = ConfiguredRequest::factory()->title($title);
+        $this->assertEquals($title, $factory->form()['title']);
     }
 
     public function test_it_can_have_state(): void
@@ -305,6 +319,13 @@ class RequestFactoryTest extends TestCase
 
         $response = AuthenticatedRequest::factory()->withTitle()->as($user)->validate();
         $response->assertSuccessful();
+    }
+
+    public function test_set_should_remove_key_from_unset(): void
+    {
+        $form = SimpleRequest::factory()->withoutTitle()->title($this->faker->word())->form();
+
+        $this->assertArrayHasKey('title', $form);
     }
 
     public function test_validate_can_set_attributes(): void

--- a/tests/Stubs/ConfiguredRequest.php
+++ b/tests/Stubs/ConfiguredRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Magdonia\LaravelFactories\Tests\Stubs;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Magdonia\LaravelFactories\Concerns\HasRequestFactory;
+
+class ConfiguredRequest extends FormRequest
+{
+    use HasRequestFactory;
+
+    /**
+     * @return string[]
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string',
+        ];
+    }
+}

--- a/tests/Stubs/ConfiguredRequestFactory.php
+++ b/tests/Stubs/ConfiguredRequestFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Magdonia\LaravelFactories\Tests\Stubs;
+
+use Magdonia\LaravelFactories\RequestFactory;
+
+/**
+ * @extends RequestFactory<ConfiguredRequestFactory>
+ */
+class ConfiguredRequestFactory extends RequestFactory
+{
+    public string $title;
+
+    protected function configure(): void
+    {
+        $this->title = $this->faker->sentence();
+    }
+
+    public function definition(): array
+    {
+        return [
+            'title' => $this->title,
+        ];
+    }
+
+    /**
+     * @return $this
+     */
+    public function title(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+}

--- a/tests/Stubs/SimpleRequestFactory.php
+++ b/tests/Stubs/SimpleRequestFactory.php
@@ -45,4 +45,15 @@ class SimpleRequestFactory extends RequestFactory
 
         return $this;
     }
+
+    /**
+     * @param string $title
+     * @return $this
+     */
+    public function title(string $title): self
+    {
+        $this->set('title', $title);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Previously it was not possible to override defined params in the definition method with set properties in the configuration method.
Example:
```php
// consider this factory
class PostRequestFactory extends RequestFactory
{
    public Category $category;

    protected function configure(): void
    {
        $this->category = Category::factory()->create();
    }

    protected function definition(): array
    {
        return [
            'title' => $this->faker->sentence(),
            'category_id' => $this->category->id,
        ];
    }

    public function category(Category $category): self
    {
        $this->category = $category;

        return $this;
    }
}
// before this failed
public function test_category_on_form(): void
{
    $category = Category::factory()->create();
    $form = PostRequest::factory()->category($category)->create();
    $this->assertEquals($category->id, $form['category_id']);
}

// after this passes
public function test_category_on_form(): void
{
    $category = Category::factory()->create();
    $form = PostRequest::factory()->category($category)->create();
    $this->assertEquals($category->id, $form['category_id']);
}

```